### PR TITLE
Allows for default values

### DIFF
--- a/userdocker/config/default.py
+++ b/userdocker/config/default.py
@@ -117,6 +117,15 @@ ARGS_AVAILABLE = {
     ],
 }
 
+# The following arguments sets default values that can be 
+# overwritten by the user.
+# Do not include these args in ARGS_AVAILABLE or ARGS_ALWAYS
+ARGS_DEFAULT = {
+    'run': {
+        #'--memory': '50m'
+    }    
+}
+
 
 # Volume mounts:
 # - VOLUME_MOUNTS_ALWAYS will be mounted whether the user wants it or not

--- a/userdocker/helpers/parser.py
+++ b/userdocker/helpers/parser.py
@@ -31,7 +31,8 @@ def init_subcommand_parser(parent_parser, scmd):
     )
 
     for arg, val in ARGS_DEFAULT.get(scmd, {}).items():
-        parser.add_argument(arg, default=[f'{arg}={val}'], dest="patch_through_args", action=_PatchThroughAssignmentAction)
+        parser.add_argument(arg, dest="patch_through_args", action=_PatchThroughAssignmentAction)
+        parser.set_defaults(patch_through_args=parser.get_default('patch_through_args') + [f'{arg}={val}'])
 
     # patch args through
     _args_seen = []

--- a/userdocker/helpers/parser.py
+++ b/userdocker/helpers/parser.py
@@ -5,6 +5,7 @@ import argparse
 
 from ..config import ARGS_ALWAYS
 from ..config import ARGS_AVAILABLE
+from ..config import ARGS_DEFAULT
 
 
 class _PatchThroughAssignmentAction(argparse._AppendAction):
@@ -28,6 +29,9 @@ def init_subcommand_parser(parent_parser, scmd):
     parser.set_defaults(
         patch_through_args=[],
     )
+
+    for arg, val in ARGS_DEFAULT.get(scmd, {}).items():
+        parser.add_argument(arg, default=[f'{arg}={val}'], dest="patch_through_args", action=_PatchThroughAssignmentAction)
 
     # patch args through
     _args_seen = []


### PR DESCRIPTION
In order to enforce smart defaults I added default arguments.

The config key `ARGS_DEFAULT` allows for definition of default arguments. Users can override these by simply setting them when calling userdocker.
It is similar to `ARGS_AVAILABLE` and using something like `--shm-size=16g` but with a variable value part.